### PR TITLE
Added timeout parameter for API objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,24 @@ except InstagramAPIError as e:
       print "\nUser is set to private."
 ```
 
+Setting Timeouts
+------
+By default there is no timeout for requests to the Instagram API. You can specify a timeout in one of two ways:
+``` python
+from instagram.client import InstagramAPI
+
+# set a 30-second timeout for this particular InstagramAPI instance
+api = InstagramAPI(access_token=access_token, client_secret=client_secret, timeout=30)
+```
+or
+``` python
+import socket
+
+# Set the global default timeout, which applies to all sockets in your 
+# program where a timeout is not otherwise specified.
+socket.setdefaulttimeout(30)
+```
+
 Trouble Shooting
 ------
 

--- a/instagram/oauth2.py
+++ b/instagram/oauth2.py
@@ -27,12 +27,13 @@ class OAuth2API(object):
     # override with 'Instagram', etc
     api_name = "Generic API"
 
-    def __init__(self, client_id=None, client_secret=None, client_ips=None, access_token=None, redirect_uri=None):
+    def __init__(self, client_id=None, client_secret=None, client_ips=None, access_token=None, redirect_uri=None, timeout=None):
         self.client_id = client_id
         self.client_secret = client_secret
         self.client_ips = client_ips
         self.access_token = access_token
         self.redirect_uri = redirect_uri
+        self.timeout = timeout
 
     def get_authorize_url(self, scope=None):
         req = OAuth2AuthExchangeRequest(self)
@@ -96,7 +97,7 @@ class OAuth2AuthExchangeRequest(object):
         return self._url_for_authorize(scope=scope)
 
     def get_authorize_login_url(self, scope=None):
-        http_object = Http(disable_ssl_certificate_validation=True)
+        http_object = Http(timeout=self.api.timeout, disable_ssl_certificate_validation=True)
 
         url = self._url_for_authorize(scope=scope)
         response, content = http_object.request(url)
@@ -107,7 +108,7 @@ class OAuth2AuthExchangeRequest(object):
 
     def exchange_for_access_token(self, code=None, username=None, password=None, scope=None, user_id=None):
         data = self._data_for_exchange(code, username, password, scope=scope, user_id=user_id)
-        http_object = Http(disable_ssl_certificate_validation=True)
+        http_object = Http(timeout=self.api.timeout, disable_ssl_certificate_validation=True)
         url = self.api.access_token_url
         response, content = http_object.request(url, method="POST", body=data)
         parsed_content = simplejson.loads(content.decode())
@@ -234,5 +235,8 @@ class OAuth2Request(object):
             headers.update({"User-Agent": "%s Python Client" % self.api.api_name})
         # https://github.com/jcgregorio/httplib2/issues/173
         # bug in httplib2 w/ Python 3 and disable_ssl_certificate_validation=True
-        http_obj = Http() if six.PY3 else Http(disable_ssl_certificate_validation=True)        
+        if six.PY3:
+            http_obj = Http(timeout=self.api.timeout) 
+        else:
+            http_obj = Http(timeout=self.api.timeout, disable_ssl_certificate_validation=True)
         return http_obj.request(url, method, body=body, headers=headers)


### PR DESCRIPTION
By default there is no timeout on requests to the InstagramAPI. This can
cause unexpected behavior if a system is not anticipating a request to
block indefinitely.

This patch stops short of imposing a default timeout value, but does
expose the ability to specify a timeout value upon creating an api object.

The README has also been updated.
